### PR TITLE
Mwayne/skip lang detection

### DIFF
--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -460,6 +460,12 @@ module Deliver
                                      type: Boolean,
                                      optional: true,
                                      default_value: true),
+        FastlaneCore::ConfigItem.new(key: :skip_language_detection,
+                                     env_name: "SKIP_LANGUAGE_DETECTION",
+                                     description: "Skip language detection in App Store Connect and use the languages specified in the languages param",
+                                     type: Boolean,
+                                     optional: true,
+                                     default_value: false),
 
         # internal
         FastlaneCore::ConfigItem.new(key: :app,

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -94,9 +94,9 @@ module Deliver
 
       enabled_languages = detect_languages
 
-      app_store_version_localizations = verify_available_version_languages!(app, enabled_languages) unless options[:edit_live]
       app_info = fetch_edit_app_info(app)
-      app_info_localizations = verify_available_info_languages!(app, app_info, enabled_languages) unless options[:edit_live] || !updating_localized_app_info?(app, app_info)
+      app_store_version_localizations = nil
+      app_info_localizations = nil
 
       if options[:edit_live]
         # not all values are editable when using live_version
@@ -118,6 +118,23 @@ module Deliver
         version = fetch_edit_app_store_version(app, platform)
         localised_options = (LOCALISED_VERSION_VALUES.keys + LOCALISED_APP_VALUES.keys)
         non_localised_options = NON_LOCALISED_VERSION_VALUES.keys
+      end
+
+      unless options[:edit_live]
+        if options[:skip_language_detection]
+          # Do not create/enable additional locales; use what already exists on ASC
+          app_store_version_localizations = version.get_app_store_version_localizations
+        else
+          app_store_version_localizations = verify_available_version_languages!(app, enabled_languages)
+        end
+
+        if updating_localized_app_info?(app, app_info)
+          if options[:skip_language_detection]
+            app_info_localizations = app_info&.get_app_info_localizations
+          else
+            app_info_localizations = verify_available_info_languages!(app, app_info, enabled_languages)
+          end
+        end
       end
 
       # Needed for to filter out release notes from being sent up

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -528,6 +528,9 @@ module Pilot
         default_info = info_by_lang.delete(:default)
       end
 
+      allowed = allowed_locales
+      info_by_lang.select! { |locale, _| allowed.include?(locale.to_s) } if allowed
+
       # Initialize hash of lang codes with info_by_lang keys
       localizations_by_lang = {}
       info_by_lang.each_key do |key|
@@ -542,6 +545,7 @@ module Pilot
 
       # Create or update localized app review info
       localizations_by_lang.each do |lang_code, localization|
+        next if allowed && !allowed.include?(lang_code.to_s)
         info = info_by_lang[lang_code]
 
         info = default_info unless info
@@ -574,6 +578,9 @@ module Pilot
         default_info = info_by_lang.delete(:default)
       end
 
+      allowed = allowed_locales
+      info_by_lang.select! { |locale, _| allowed.include?(locale.to_s) } if allowed
+
       # Initialize hash of lang codes with info_by_lang keys
       localizations_by_lang = {}
       info_by_lang.each_key do |key|
@@ -588,11 +595,21 @@ module Pilot
 
       # Create or update localized app review info
       localizations_by_lang.each do |lang_code, localization|
+        next if allowed && !allowed.include?(lang_code.to_s)
         info = info_by_lang[lang_code]
 
         info = default_info unless info
         update_localized_build_review_for_lang(build, localization, lang_code, info) if info
       end
+    end
+
+    def allowed_locales
+      langs = config[:languages]
+      langs ||= ENV["LANGUAGES"]
+      return nil unless langs
+
+      langs = langs.split(",") unless langs.kind_of?(Array)
+      langs.map { |l| l.to_s.strip }.reject(&:empty?)
     end
 
     def update_localized_build_review_for_lang(build, localization, locale, info)

--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -154,6 +154,11 @@ module Pilot
                                          values.keys.each { |value| UI.user_error!("Invalid key '#{value}'") unless valid_keys.include?(value.to_s) }
                                        end
                                      end),
+        FastlaneCore::ConfigItem.new(key: :languages,
+                                     type: Array,
+                                     env_name: "LANGUAGES",
+                                     description: "List of locales permitted for localized build/app info (e.g. en-US,de-DE). If set, Pilot will ignore other locales when updating localized beta metadata",
+                                     optional: true),
         FastlaneCore::ConfigItem.new(key: :changelog,
                                      short_option: "-w",
                                      optional: true,


### PR DESCRIPTION
### Description

- Uses langs specified in env files for beta uploads
- Skips lang detection for release uploads

### Testing Steps

[Beta uploads](https://github.com/scribd/iscribd/actions/runs/20727987472)
[Release uploads](https://github.com/scribd/iscribd/actions/runs/20728950092)

<img width="2728" height="1108" alt="image" src="https://github.com/user-attachments/assets/01a31105-f802-4af1-bc73-c67778847fb8" />

<img width="2482" height="1026" alt="image" src="https://github.com/user-attachments/assets/f64a21f7-338e-4bf1-ad55-fa154f476c89" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces explicit control over which locales are used/updated during uploads.
> 
> - **Deliver**: New `skip_language_detection` option in `options.rb`. When set (and not `edit_live`), `upload_metadata.rb` uses existing App Store Connect localizations via `version.get_app_store_version_localizations` and `app_info.get_app_info_localizations` instead of `verify_available_*_languages!` (no new locales are created/enabled).
> - **Pilot**: New `languages` option (and `LANGUAGES` env) in `options.rb`. `build_manager.rb` adds `allowed_locales` and filters `update_localized_app_review`/`update_localized_build_review` to only update locales in this list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d230614929cff96ce44234271eba46c8642d6c78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->